### PR TITLE
Refresh tokens

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -30,6 +30,7 @@ export declare class TnsOAuthClient {
   tokenResult: ITnsOAuthTokenResult;
   constructor(providerType: TnsOaProviderType);
   loginWithCompletion(completion?: TnsOAuthClientLoginBlock): void;
+  refreshTokenWithCompletion(completion?: TnsOAuthClientLoginBlock): void;
   resumeWithUrl(url: string): void;
   logout(successPage?: string): void;
   // private removeCookies();

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-oauth2",
-  "version": "1.1.5-beta.2",
+  "version": "1.1.4",
   "description": "OAuth 2 login for NativeScript.",
   "main": "oauth",
   "typings": "index.d.ts",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-oauth2",
-  "version": "1.1.4",
+  "version": "1.1.5-beta.2",
   "description": "OAuth 2 login for NativeScript.",
   "main": "oauth",
   "typings": "index.d.ts",


### PR DESCRIPTION
Fixes #4 by adding support for refresh tokens. This also fixes a bug with scopes necessary for refresh tokens to work - previously, the requested scopes would get included multiple times in the oauth request, once per each scope. Instead, the scopes should be space separated in one parameter. This was necessary to fix for this PR because the scope "offline_access" is required to get a refresh token.