### PR TITLE
feat: Send notification that the user cancelled the login WebView

### DIFF
--- a/src/tns-oauth-login-webview-controller.ts
+++ b/src/tns-oauth-login-webview-controller.ts
@@ -18,6 +18,7 @@ import {
 export class TnsOAuthLoginWebViewController
   implements ITnsOAuthLoginController {
   private loginController: TnsOAuthLoginSubController = null;
+  private unbindCancelEvent: () => void;
 
   public static initWithClient(client: TnsOAuthClient) {
     const instance = new TnsOAuthLoginWebViewController();
@@ -69,6 +70,12 @@ export class TnsOAuthLoginWebViewController
     navBtn.text = "Done";
     page.actionBar.navigationButton = navBtn;
 
+    const onCancel = () => {
+      this.loginController.completeLoginWithTokenResponseError(null, new Error("User cancelled."));
+    };
+    page.on("navigatedFrom", onCancel);
+    this.unbindCancelEvent = () => page.off("navigatedFrom", onCancel);
+
     return page;
   }
 
@@ -92,6 +99,9 @@ export class TnsOAuthLoginWebViewController
           tokenResult,
           error
         );
+        if (this.unbindCancelEvent) {
+          this.unbindCancelEvent();
+        }
         this.loginController.frame.goBack();
       }
     );


### PR DESCRIPTION
This is a port of my own [pull request for the old version](https://github.com/alexziskind1/nativescript-oauth/pull/74). It sends an error through the login callback when the user cancels, which is useful for when chaining the result into an Observable, among other use cases. This only applies to the WebView login flow - I don't have enough expertise about how the other login flows work to modify them as well.