### PR TITLE
feat: custom query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,10 @@ function configureOAuthProviderMyCustomProvider(): TnsOaProvider {
     clientId: "<your client/app id>",
     clientSecret: "<your client secret>",
     redirectUri: "<redirect Uri>",
-    scopes: ["email"]
+    scopes: ["email"],
+    customQueryParams: {
+      foo: "bar"
+    }
   };
   const facebookProvider = new TnsOaProviderMyCustomProvider(facebookProviderOptions);
   return facebookProvider;

--- a/src/providers/providers.d.ts
+++ b/src/providers/providers.d.ts
@@ -9,6 +9,7 @@ export interface TnsOaProviderOptions {
   clientId: string;
   redirectUri: string;
   scopes?: string[];
+  customQueryParams?: { [paramName: string]: string };
 }
 
 export interface TnsOaUnsafeProviderOptions extends TnsOaProviderOptions {

--- a/src/tns-oauth-utils.ts
+++ b/src/tns-oauth-utils.ts
@@ -4,6 +4,15 @@ import * as UrlLib from "url";
 import { TnsOaProvider } from "./providers";
 import { ITnsOAuthTokenResult } from ".";
 
+function addCustomQueryParams(params: object, provider: TnsOaProvider): void {
+  const customQueryParams = provider.options.customQueryParams;
+  if (customQueryParams) {
+    for (const paramName of Object.keys(customQueryParams)) {
+      params[paramName] = customQueryParams[paramName];
+    }
+  }
+}
+
 export function getAuthUrlStr(provider: TnsOaProvider): string {
   if (provider.getAuthUrlStr) {
     return provider.getAuthUrlStr();
@@ -15,6 +24,8 @@ export function getAuthUrlStr(provider: TnsOaProvider): string {
   params["scope"] = provider.options.scopes && provider.options.scopes.join(' ');
   params["response_mode"] = "query";
   params["state"] = "abcd";
+
+  addCustomQueryParams(params, provider);
 
   const pararmsStr = querystring.stringify(params);
 
@@ -63,6 +74,8 @@ export function getAccessTokenUrlWithCodeStr(
   params["scope"] = provider.options.scopes && provider.options.scopes.join(' ');
   // params["response_mode"] = "query";
   params["state"] = "abcd";
+
+  addCustomQueryParams(params, provider);
 
   const pararmsStr = querystring.stringify(params);
 


### PR DESCRIPTION
This adds `customQueryParams` to `TnsOaProviderOptions`, and includes the params on every authorize request. It's meant to mimic a feature of the same name from [angular-oauth2-oidc](https://github.com/manfredsteyer/angular-oauth2-oidc). It's useful for when your custom identity server needs special parameters, such as acr_values.