### PR TITLE
perf(ITnsOAuthTokenResult): Removed refreshTokenExpiration property

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,7 +9,6 @@ export declare interface ITnsOAuthTokenResult {
   refreshToken: string;
   idToken: string;
   accessTokenExpiration: Date;
-  refreshTokenExpiration: Date;
   idTokenExpiration: Date;
 }
 

--- a/src/tns-oauth-utils.ts
+++ b/src/tns-oauth-utils.ts
@@ -160,7 +160,6 @@ export function httpResponseToToken(response: http.HttpResponse): ITnsOAuthToken
     refreshToken: refresh_token,
     idToken: id_token,
     accessTokenExpiration: expDate,
-    refreshTokenExpiration: expDate,
     idTokenExpiration: expDate
   };
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
`ITnsOAuthTokenResult` interface has `refreshTokenExpiration` which is same as `accessTokenExpiration`, Refresh tokens do not have an expiry.

## What is the new behavior?
`refreshTokenExpiration` property removed.