### PR TITLE
Reorder logout methods.

### DIFF
--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -70,9 +70,9 @@ export class TnsOAuthClient {
   }
 
   public logout() {
+    this.callRevokeEndpoint();
     this.removeCookies();
     this.removeToken();
-    this.callRevokeEndpoint();
   }
 
   public resumeWithUrl(url: string) {


### PR DESCRIPTION
Hey Alex,

I am using your plugin in a project where I need to call the revocation endpoint in order to sign out. As the method callRevokeEndpoint() in logout() needs the clients token to execute the token should be removed after the revocation endpoint is called.

So I simply changed the order the methods are called and so its working as expected.

Cheers
Paul