### PR TITLE
Fix network errors being swallowed by logout and token refresh

### DIFF
--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -14,7 +14,11 @@ import { TnsOAuthClientAppDelegate } from "./delegate";
 import { TnsOAuthLoginNativeViewController } from "./tns-oauth-native-view-controller";
 import { TnsOAuthLoginWebViewController } from "./tns-oauth-login-webview-controller";
 import { TnsOAuthClientConnection } from "./tns-oauth-client-connection";
-import { nsArrayToJSArray, jsArrayToNSArray, httpResponseToToken } from "./tns-oauth-utils";
+import {
+  nsArrayToJSArray,
+  jsArrayToNSArray,
+  httpResponseToToken
+} from "./tns-oauth-utils";
 
 export class TnsOAuthClient {
   public provider: TnsOaProvider = null;
@@ -113,7 +117,7 @@ export class TnsOAuthClient {
                   () => {
                     console.log(
                       `Cookies for ${
-                      cookieRecord.displayName
+                        cookieRecord.displayName
                       } deleted successfully`
                     );
                   }
@@ -168,7 +172,9 @@ export class TnsOAuthClient {
     connection.startTokenRevocation();
   }
 
-  private callRefreshEndpointWithCompletion(completion?: TnsOAuthClientLoginBlock) {
+  private callRefreshEndpointWithCompletion(
+    completion?: TnsOAuthClientLoginBlock
+  ) {
     if (!this.provider.tokenEndpoint) {
       return;
     }
@@ -177,7 +183,9 @@ export class TnsOAuthClient {
       // request,
       this,
       (data, result, error) => {
-        this.tokenResult = httpResponseToToken(result);
+        if (result) {
+          this.tokenResult = httpResponseToToken(result);
+        }
         completion(this.tokenResult, error);
       }
     );

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-oauth2",
-  "version": "1.1.4",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -418,25 +418,25 @@
       "dev": true
     },
     "tns-core-modules": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/tns-core-modules/-/tns-core-modules-5.0.5.tgz",
-      "integrity": "sha512-AUwrn6TIhrTc88IO9X7SU4otT/dU84CPfHtAZHW+D05/alkkupfqrbHtQXjDH+TBkwiKbq48dBmI6OpM9Pablg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/tns-core-modules/-/tns-core-modules-5.4.0.tgz",
+      "integrity": "sha512-3WI2yJm+ihjrRefOjEABSHFy19r3UCYfbhzlb0eJUDguLKIC+/ZGHIGp8GT4hAU6YbtA4AZfZlvrz5coGlv0ZA==",
       "dev": true,
       "requires": {
-        "tns-core-modules-widgets": "5.0.1",
+        "tns-core-modules-widgets": "5.4.0",
         "tslib": "^1.9.3"
       }
     },
     "tns-core-modules-widgets": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/tns-core-modules-widgets/-/tns-core-modules-widgets-5.0.1.tgz",
-      "integrity": "sha512-zDml+PISblTkAQ+Xd4JcMHl/o5dpAn0B+R2fLtxWjNIhkNzNfz+FmfMtH7Js2wnwtLp+kC2ZNOQRVAzOBquxAQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/tns-core-modules-widgets/-/tns-core-modules-widgets-5.4.0.tgz",
+      "integrity": "sha512-ZRK0VU+JonueO3n2RcVo1Tp51kn4GeblvTwyHxJtbrvZdb3q/1gIbyni3wsm3uyHYjo4YiFjxKoJap4QDvB4+w==",
       "dev": true
     },
     "tns-platform-declarations": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/tns-platform-declarations/-/tns-platform-declarations-5.0.5.tgz",
-      "integrity": "sha512-paU+SgAPsDC3VH6YfvkQdfCzp24i+40sDz1L99AA2TCgqVnlrwgBxc25dhK18ai2gQR/ZqN3amYrexBnf4MUQQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/tns-platform-declarations/-/tns-platform-declarations-5.4.0.tgz",
+      "integrity": "sha512-8lb2F5k0CWBF3DKqFwN8/UJtf7m/gd3/FRILqAHCIYJq/PHTcm9aim9fU0cbR5sysj8XAO6d1XRJ7O5MuM6F6w==",
       "dev": true
     },
     "tslib": {
@@ -475,9 +475,9 @@
       }
     },
     "typescript": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.4.tgz",
-      "integrity": "sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.1.tgz",
+      "integrity": "sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==",
       "dev": true
     },
     "url": {

--- a/src/tns-oauth-client-connection.ts
+++ b/src/tns-oauth-client-connection.ts
@@ -112,12 +112,7 @@ export class TnsOAuthClientConnection {
             this.completion(null, response, null);
           }
         },
-        error =>
-          this.completion(
-            null,
-            error,
-            new Error(`Failed logout due to network error.`)
-          )
+        error => this.completion(null, null, error)
       );
   }
 
@@ -172,12 +167,7 @@ export class TnsOAuthClientConnection {
             this.completion(null, response, null);
           }
         },
-        error =>
-          this.completion(
-            null,
-            error,
-            new Error(`Failed refresh token due to network error.`)
-          )
+        error => this.completion(null, null, error)
       );
   }
 

--- a/src/tns-oauth-client-connection.ts
+++ b/src/tns-oauth-client-connection.ts
@@ -100,17 +100,25 @@ export class TnsOAuthClientConnection {
         headers: headers,
         content: body
       })
-      .then((response: http.HttpResponse) => {
-        if (response.statusCode !== 200) {
+      .then(
+        (response: http.HttpResponse) => {
+          if (response.statusCode !== 200) {
+            this.completion(
+              null,
+              response,
+              new Error(`Failed logout with status ${response.statusCode}.`)
+            );
+          } else {
+            this.completion(null, response, null);
+          }
+        },
+        error =>
           this.completion(
             null,
-            response,
-            new Error(`Failed logout with status ${response.statusCode}.`)
-          );
-        } else {
-          this.completion(null, response, null);
-        }
-      });
+            error,
+            new Error(`Failed logout due to network error.`)
+          )
+      );
   }
 
   public startTokenRefresh() {
@@ -122,15 +130,19 @@ export class TnsOAuthClientConnection {
     let body = null;
     switch (this.client.provider.options.openIdSupport) {
       case "oid-full":
-        const options1 = <TnsOaOpenIdProviderOptions>this.client.provider.options;
+        const options1 = <TnsOaOpenIdProviderOptions>(
+          this.client.provider.options
+        );
         body = querystring.stringify({
           grant_type: "refresh_token",
           refresh_token: this.client.tokenResult.refreshToken,
           client_id: options1.clientId
         });
         break;
-        case "oid-none":
-        const options2 = <TnsOaUnsafeProviderOptions>this.client.provider.options;
+      case "oid-none":
+        const options2 = <TnsOaUnsafeProviderOptions>(
+          this.client.provider.options
+        );
         body = querystring.stringify({
           grant_type: "refresh_token",
           refresh_token: this.client.tokenResult.refreshToken,
@@ -146,17 +158,27 @@ export class TnsOAuthClientConnection {
         headers: headers,
         content: body
       })
-      .then((response: http.HttpResponse) => {
-        if (response.statusCode !== 200) {
+      .then(
+        (response: http.HttpResponse) => {
+          if (response.statusCode !== 200) {
+            this.completion(
+              null,
+              response,
+              new Error(
+                `Failed refresh token with status ${response.statusCode}.`
+              )
+            );
+          } else {
+            this.completion(null, response, null);
+          }
+        },
+        error =>
           this.completion(
             null,
-            response,
-            new Error(`Failed refresh token with status ${response.statusCode}.`)
-          );
-        } else {
-          this.completion(null, response, null);
-        }
-      });
+            error,
+            new Error(`Failed refresh token due to network error.`)
+          )
+      );
   }
 
   private getTokenFromCode(


### PR DESCRIPTION
The logout and refresh functions don't catch promise errors on their HTTP requests, which means that network errors (and possible others) don't make their way to the error callback, and instead log an unhandled promise rejection to the console. This PR catches the errors and sends them through the callback.