### PR TITLE
Return original data from token response

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,6 +11,7 @@ export declare interface ITnsOAuthTokenResult {
   accessTokenExpiration: Date;
   refreshTokenExpiration: Date;
   idTokenExpiration: Date;
+  original: any;
 }
 
 export type TnsOAuthClientLoginBlock = (

--- a/src/tns-oauth-utils.ts
+++ b/src/tns-oauth-utils.ts
@@ -156,6 +156,7 @@ export function httpResponseToToken(response: http.HttpResponse): ITnsOAuthToken
   expDate.setSeconds(expDate.getSeconds() + expSecs);
 
   return {
+    original: results,
     accessToken: access_token,
     refreshToken: refresh_token,
     idToken: id_token,


### PR DESCRIPTION
I'm using authentication through my own server as described here: https://github.com/sahat/satellizer#-login-with-oauth-20
So, I need to save a JWT token for interacting with server in future.
Now returned data can't include something different to accessToken, refreshToken etc. So, I add original data to object that produce from response. In this case I can add any useful information to server's response.