### PR TITLE
removed back navigation from android controller

### DIFF
--- a/src/tns-oauth-native-view-controller.android.ts
+++ b/src/tns-oauth-native-view-controller.android.ts
@@ -80,7 +80,6 @@ export class TnsOAuthLoginNativeViewController
           tokenResult,
           error
         );
-        this.loginController.frame.goBack();
       }
     );
   }


### PR DESCRIPTION
Hello @alexziskind1 ,

Could you review this pr?

Removed the back navigation from the android controller method "resumeWithUrl".
Not sure why it was there, it was causing undesired navigation after login/logout.
For example the user got a redirect back to the last page they visited after logout. If this was a page with authorization guard you were immediately asked to login again (after logging out)

The ios container does not contain a back navigation in this method and works as expected.

Not sure what the impact is on other projects/situations. In my opinion the back navigation should not be part of the library, it is part of business logic belonging to the individual project. Any navigation should be done by the developer in the completion method or something similar.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
(android only)
After login/logout the app redirects back to the previously visited page page

## What is the new behavior?
After login/logout the app opens on the current page (no back navigation)

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:



Migration steps:
[Provide a migration path for existing applications.]
-->

