### PR TITLE
Cancel login operation on Android on back or native view closing

### DIFF
--- a/src/delegate/delegate.android.ts
+++ b/src/delegate/delegate.android.ts
@@ -9,12 +9,14 @@ appModule.android.on(
           new String(args.activity.getIntent().getAction()).valueOf() ===
           new String(android.content.Intent.ACTION_VIEW).valueOf()
       ) {
-        const url = args.activity
-            .getIntent()
-            .getData()
-            .toString();
-        TnsOAuthClientAppDelegate._client.resumeWithUrl(url);
-        console.log(args.activity.getIntent().getData());
+          const url = args.activity
+              .getIntent()
+              .getData()
+              .toString();
+          TnsOAuthClientAppDelegate._client.resumeWithUrl(url);
+          console.log(args.activity.getIntent().getData());
+      } else {
+          TnsOAuthClientAppDelegate._client.resumeWithUrl(null);
       }
     }
 );

--- a/src/tns-oauth-native-view-controller.android.ts
+++ b/src/tns-oauth-native-view-controller.android.ts
@@ -73,7 +73,8 @@ export class TnsOAuthLoginNativeViewController
   }
 
   public resumeWithUrl(url: string): boolean {
-    return this.loginController.resumeWithUrl(
+    if (!!url) {
+      return this.loginController.resumeWithUrl(
       url,
       (tokenResult: ITnsOAuthTokenResult, error) => {
         this.loginController.completeLoginWithTokenResponseError(
@@ -83,5 +84,10 @@ export class TnsOAuthLoginNativeViewController
         this.loginController.frame.goBack();
       }
     );
+    } else {
+      const er = "The login operation was canceled.";
+      this.loginController.completeLoginWithTokenResponseError(null, er);
+      return true;
+    }
   }
 }


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
When closing the window or pressing back button on Android the login operation is not cancelled. Therefore it is not possible to launch a new login operation and we are stuck in a loophole. 
This feature is already implemented for iOS

## What is the new behavior?
It resumes the activity with a null url to allow differentiate a successful login from a user cancelled login.

Fixes/Implements/Closes #50.
With this fix the error is never encountered anymore.
