### PR TITLE
(fix) logout workflow now appropriately terminates the native view an…

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -59,7 +59,7 @@ export interface ITnsOAuthLoginController {
     parameters,
     frame: Frame,
     urlScheme?: string,
-    completion?: TnsOAuthClientLoginBlock
+    completion?: TnsOAuthClientLogoutBlock
   );
   resumeWithUrl(url: string);
 }

--- a/src/tns-oauth-auth-state.ts
+++ b/src/tns-oauth-auth-state.ts
@@ -4,6 +4,7 @@ export class TnsOAuthState {
   private _loginCompletion: TnsOAuthClientLoginBlock;
   private _codeVerifier: string;
   private _urlScheme: string;
+  private _isLogout: boolean;
 
   public authCode: string;
 
@@ -19,13 +20,19 @@ export class TnsOAuthState {
     return this._urlScheme;
   }
 
+  public get isLogout(): boolean {
+    return this._isLogout;
+  }
+
   constructor(
     codeVerifier: string,
+    isLogout: boolean,
     loginCompletion?: TnsOAuthClientLoginBlock,
     urlScheme?: string
   ) {
     this._loginCompletion = loginCompletion;
     this._codeVerifier = codeVerifier;
     this._urlScheme = urlScheme;
+    this._isLogout = isLogout;
   }
 }

--- a/src/tns-oauth-login-webview-controller.ts
+++ b/src/tns-oauth-login-webview-controller.ts
@@ -10,7 +10,7 @@ import {
   TnsOAuthClientLoginBlock,
   TnsOAuthPageLoadStarted,
   TnsOAuthPageLoadFinished,
-  TnsOAuthResponseBlock
+  TnsOAuthClientLogoutBlock
 } from "./index";
 import {
   ITnsOAuthLoginController,
@@ -52,7 +52,7 @@ export class TnsOAuthLoginWebViewController
     parameters,
     frame: Frame,
     urlScheme?: string,
-    completion?: TnsOAuthResponseBlock
+    completion?: TnsOAuthClientLogoutBlock
   ) {
     const fullUrl = this.loginController.preLogoutSetup(
       frame,

--- a/src/tns-oauth-native-view-controller.android.ts
+++ b/src/tns-oauth-native-view-controller.android.ts
@@ -1,7 +1,7 @@
 import * as appModule from "tns-core-modules/application";
 import * as colorModule from "tns-core-modules/color";
 import { Frame } from "tns-core-modules/ui/frame";
-import { TnsOAuthClient, ITnsOAuthTokenResult, TnsOAuthResponseBlock } from "./index";
+import { TnsOAuthClient, ITnsOAuthTokenResult, TnsOAuthClientLogoutBlock } from "./index";
 import { TnsOAuthClientLoginBlock } from "./index";
 import {
   ITnsOAuthLoginController,
@@ -47,7 +47,7 @@ export class TnsOAuthLoginNativeViewController
     parameters,
     frame: Frame,
     urlScheme?: string,
-    completion?: TnsOAuthResponseBlock
+    completion?: TnsOAuthClientLogoutBlock
   ) {
     const fullUrl = this.loginController.preLogoutSetup(
       frame,

--- a/src/tns-oauth-native-view-controller.ios.ts
+++ b/src/tns-oauth-native-view-controller.ios.ts
@@ -3,7 +3,7 @@ import {
   TnsOAuthClient,
   ITnsOAuthTokenResult,
   TnsOAuthClientLoginBlock,
-  TnsOAuthResponseBlock
+  TnsOAuthClientLogoutBlock
 } from "./index";
 import {
   ITnsOAuthLoginController,
@@ -44,7 +44,7 @@ export class TnsOAuthLoginNativeViewController extends NSObject
     parameters,
     frame: Frame,
     urlScheme?: string,
-    completion?: TnsOAuthResponseBlock
+    completion?: TnsOAuthClientLogoutBlock
   ) {
     const fullUrl = this.loginController.preLogoutSetup(
       frame,


### PR DESCRIPTION
…d throws out cookies and tokens.

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
Using `logout` in a client application doesn't reset the browser state, so subsequent `loginWithCompletion` calls automatically log back in. In order to reset the browser state, `logoutWithCompletion` would be the expected method to call, but it had the wrong callback method signature and wasn't handling `resumeWithUrl` appropriately.

## What is the new behavior?
`resumeWithUrl` now detects that the `authState` is in a logout workflow, then doesn't try to request a token (because there isn't one). The controller is appropriately removed from the screen on success and the logout tokens are cleared once the app is visible again.
