### PR TITLE
fixes issue with overwritten app delegates; issue: #107

### DIFF
--- a/src/delegate/delegate.android.ts
+++ b/src/delegate/delegate.android.ts
@@ -31,4 +31,8 @@ export class TnsOAuthClientAppDelegate {
     this._client = client;
     this._urlScheme = urlScheme;
   }
+
+  public static doRegisterDelegates() {
+
+  }
 }

--- a/src/delegate/delegate.d.ts
+++ b/src/delegate/delegate.d.ts
@@ -2,4 +2,5 @@ import { TnsOAuthClient } from "../index";
 
 export declare class TnsOAuthClientAppDelegate {
   public static setConfig(client: TnsOAuthClient, urlScheme: string);
+  public static doRegisterDelegates();
 }

--- a/src/delegate/delegate.ios.ts
+++ b/src/delegate/delegate.ios.ts
@@ -1,8 +1,8 @@
 import { TnsOAuthClient } from "../index";
+import * as applicationModule from "tns-core-modules/application";
+// import * as platformModule from "tns-core-modules/platform";
 
-@ObjCClass(UIApplicationDelegate)
-export class TnsOAuthClientAppDelegate extends UIResponder
-  implements UIApplicationDelegate {
+export class TnsOAuthClientAppDelegate {
   private static _client: TnsOAuthClient;
   private static _urlScheme: string;
 
@@ -11,40 +11,46 @@ export class TnsOAuthClientAppDelegate extends UIResponder
     this._urlScheme = urlScheme;
   }
 
-  // iOS >= 10
-  public applicationOpenURLOptions(
-    application: UIApplication,
-    url: NSURL,
-    options: NSDictionary<string, any>
-  ): boolean {
-    return this.handleIncomingUrl(url);
-  }
-
-  // iOS < 10
-  public applicationOpenURLSourceApplicationAnnotation?(
-    application: UIApplication,
-    url: NSURL,
-    sourceApplication: string,
-    annotation: any
-  ): boolean {
-    return this.handleIncomingUrl(url);
-  }
-
-  private handleIncomingUrl(url: NSURL): boolean {
-    if (
-      !TnsOAuthClientAppDelegate._client ||
-      !TnsOAuthClientAppDelegate._urlScheme
-    ) {
-      // the delegate wasn't wired to the client, that should have resulted in an errormessage already
-      console.log("IMPORTANT: Could not complete login flow.");
-      return false;
-    }
-
-    if (url.scheme.toLowerCase() === TnsOAuthClientAppDelegate._urlScheme) {
-      TnsOAuthClientAppDelegate._client.resumeWithUrl(url.absoluteString);
-      return true;
+  private static getAppDelegate() {
+    // Play nice with other plugins by not completely ignoring anything already added to the appdelegate
+    if (applicationModule.ios.delegate === undefined) {
+      console.log("creating new delegate");
+      @ObjCClass(UIApplicationDelegate)
+      class UIApplicationDelegateImpl extends UIResponder implements UIApplicationDelegate {
+      }
+  
+      applicationModule.ios.delegate = UIApplicationDelegateImpl;
     } else {
-      return false;
+      console.log("returning existing delegate");
     }
+    return applicationModule.ios.delegate;
   }
+  
+  private static addAppDelegateMethods = appDelegate => {
+      console.log("fired: addAppDelegateMethods");
+      
+      appDelegate.prototype.applicationOpenURLOptions = (application: UIApplication, url: NSURL, options: NSDictionary<string, any>) => {
+        console.log("fired: " + url);
+        if (
+          !TnsOAuthClientAppDelegate._client ||
+          !TnsOAuthClientAppDelegate._urlScheme
+        ) {
+          // the delegate wasn't wired to the client, that should have resulted in an errormessage already
+          console.log("IMPORTANT: Could not complete login flow.");
+          return false;
+        }
+    
+        if (url.scheme.toLowerCase() === TnsOAuthClientAppDelegate._urlScheme) {
+          TnsOAuthClientAppDelegate._client.resumeWithUrl(url.absoluteString);
+          return true;
+        } else {
+          return false;
+        }
+      };
+  }
+
+  public static doRegisterDelegates() {
+    this.addAppDelegateMethods(this.getAppDelegate());
+  }
+
 }

--- a/src/delegate/delegate.ios.ts
+++ b/src/delegate/delegate.ios.ts
@@ -18,16 +18,16 @@ export class TnsOAuthClientAppDelegate {
       class UIApplicationDelegateImpl extends UIResponder implements UIApplicationDelegate { }
 
       applicationModule.ios.delegate = UIApplicationDelegateImpl;
-    } 
+    }
     return applicationModule.ios.delegate;
   }
-  
+
   private static addAppDelegateMethods = appDelegate => {
       if (parseInt(platformModule.device.osVersion.split('.')[0]) >= 10 ) {
         // iOS >= 10
         appDelegate.prototype.applicationOpenURLOptions = (
-              application: UIApplication, 
-              url: NSURL, 
+              application: UIApplication,
+              url: NSURL,
               options: NSDictionary<string, any>) => {
           TnsOAuthClientAppDelegate.handleIncomingUrl(url);
         };

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -238,8 +238,12 @@ export class TnsOauthProviderMap {
 
 export const tnsOauthProviderMap = new TnsOauthProviderMap();
 
+
+  
 function configureClientAuthAppDelegate(): void {
-  applicationModule.ios.delegate = TnsOAuthClientAppDelegate;
+    // applicationModule.ios.delegate = TnsOAuthClientAppDelegate;
+    console.log("fired: configureClientAuthAppDelegate()");
+    TnsOAuthClientAppDelegate.doRegisterDelegates();
 }
 
 export function configureTnsOAuth(providers: TnsOaProvider[]) {

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -238,18 +238,10 @@ export class TnsOauthProviderMap {
 
 export const tnsOauthProviderMap = new TnsOauthProviderMap();
 
-
-  
-function configureClientAuthAppDelegate(): void {
-    // applicationModule.ios.delegate = TnsOAuthClientAppDelegate;
-    console.log("fired: configureClientAuthAppDelegate()");
-    TnsOAuthClientAppDelegate.doRegisterDelegates();
-}
-
 export function configureTnsOAuth(providers: TnsOaProvider[]) {
   if (platformModule.isIOS) {
     if (providers.some(p => p.options.openIdSupport === "oid-full")) {
-      configureClientAuthAppDelegate();
+      TnsOAuthClientAppDelegate.doRegisterDelegates();
     }
   }
 


### PR DESCRIPTION
## What is the current behavior?
see issue #107 

## What is the new behavior?
Check for existing app delegate and modify that instead of recreating and therefore overwriting other plugins registrations.

Fixes/Implements/Closes #107 .

replaces PR #108 // fixed trailing whitespaces that caused travis to fail