### PR TITLE
(fix) login workflow now executes callback with 'incomplete' error message instead of silently returning

### DIFF
--- a/src/tns-oauth-login-sub-controller.ts
+++ b/src/tns-oauth-login-sub-controller.ts
@@ -90,13 +90,15 @@ export class TnsOAuthLoginSubController {
     completion: TnsOAuthClientLoginBlock | TnsOAuthClientLogoutBlock
   ): boolean {
     if (this.authState) {
-      if (
-        this.authState.isLogout &&
-        url.startsWith(this.client.provider.options.redirectUri)
-      ) {
-        this.client.logout();
-        (completion as TnsOAuthClientLogoutBlock)(undefined);
-        return true;
+      if (this.authState.isLogout) {
+        if (url === this.client.provider.options.redirectUri) {
+          this.client.logout();
+          (completion as TnsOAuthClientLogoutBlock)(undefined);
+          return true;
+        } else {
+          (completion as TnsOAuthClientLogoutBlock)(`incomplete`);
+          return false;
+        }
       } else {
         const codeExchangeRequestUrl: string = this.codeExchangeRequestUrlFromRedirectUrl(
           url
@@ -108,10 +110,11 @@ export class TnsOAuthLoginSubController {
             completion
           );
           return true;
+        } else {
+          (completion as TnsOAuthClientLoginBlock)(undefined, `incomplete`);
         }
       }
     }
-
     return false;
   }
 


### PR DESCRIPTION
## Steps to Reproduce
- Log in.
- Log out.
- Trigger a new login process, but intentionally fail.
- Close the browser to return to the app.

On Android, there is no callback fired, causing the app to resume but not be notified that the process was terminated.

BREAKING CHANGES:

There are now additional triggers for executing the login and logout completion handlers. This could cause unexpected (though not incorrect) error notifications.