### PR TITLE
Urlencode the redirectUri

### DIFF
--- a/src/tns-oauth-client-connection.ts
+++ b/src/tns-oauth-client-connection.ts
@@ -251,7 +251,7 @@ export class TnsOAuthClientConnection {
 
     let post_data = querystring.stringify(params);
     post_data =
-      post_data + "&redirect_uri=" + client.provider.options.redirectUri;
+      post_data + "&redirect_uri=" + encodeURIComponent(client.provider.options.redirectUri);
 
     const post_headers = {
       "Content-Type": "application/x-www-form-urlencoded"


### PR DESCRIPTION
In my case, the signature hash, and thus the redirect Uri, contains an `=`. It is already encoded into `%3D` when I copy it from the Azure Portal, but it has to be passed as `%253D` when passing it into the HTTP request method, because somewhere along the line it is decoded and won't come across correctly.

The error I got was that the redirect_uri didn't match the one from the Azure Portal. After this change, it worked as expected.

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<!-- Describe the changes. -->

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

