### PR TITLE
fixed resumeWithUrl issue when using with nativescript-urlhandler.

### DIFF
--- a/src/delegate/delegate.android.ts
+++ b/src/delegate/delegate.android.ts
@@ -13,7 +13,9 @@ appModule.android.on(
         .getIntent()
         .getData()
         .toString();
-      TnsOAuthClientAppDelegate._client.resumeWithUrl(url);
+      if (TnsOAuthClientAppDelegate._client) {
+        TnsOAuthClientAppDelegate._client.resumeWithUrl(url);
+      }
       console.log(args.activity.getIntent().getData());
     } else {
       if (TnsOAuthClientAppDelegate._client) {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
When using the plugin with [https://github.com/hypery2k/nativescript-urlhandler](https://github.com/hypery2k/nativescript-urlhandler), it's causing an error `Cannot read property 'resumeWithUrl' of undefined`

## What is the new behavior?
Checks if the `TnsOAuthClientAppDelegate._client` is null before calling the `resumeWithUrl` method.

Fixes/Implements/Closes #105 .