### PR TITLE
fixes issue of invalid url when logging out from Microsoft account #143

### DIFF
--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -42,18 +42,6 @@ export class TnsOAuthClient {
             this,
             (<any>this.provider.options).urlScheme
           );
-          console.log(
-            "TnsOAuthLoginNativeViewController:",
-            TnsOAuthLoginNativeViewController
-          );
-          console.log(
-            "typeof TnsOAuthLoginNativeViewController:",
-            typeof TnsOAuthLoginNativeViewController
-          );
-          console.log(
-            "TnsOAuthLoginNativeViewController.initWithClient:",
-            TnsOAuthLoginNativeViewController.initWithClient
-          );
           this.loginController = TnsOAuthLoginNativeViewController.initWithClient(
             this
           );

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -56,6 +56,7 @@ export class TnsOaProviderMicrosoft implements TnsOaProvider {
   public tokenEndpointBase = "https://login.microsoftonline.com/common";
   public authorizeEndpoint = "/oauth2/v2.0/authorize";
   public tokenEndpoint = "/oauth2/v2.0/token";
+  public endSessionEndpoint = '/oauth2/v2.0/logout';
   public cookieDomains = ["login.microsoftonline.com", "live.com"];
 
   constructor(options: TnsOaProviderOptionsMicrosoft) {

--- a/src/tns-oauth-login-sub-controller.ts
+++ b/src/tns-oauth-login-sub-controller.ts
@@ -92,7 +92,7 @@ export class TnsOAuthLoginSubController {
     if (this.authState) {
       if (
         this.authState.isLogout &&
-        url === this.client.provider.options.redirectUri
+        url.startsWith(this.client.provider.options.redirectUri)
       ) {
         this.client.logout();
         (completion as TnsOAuthClientLogoutBlock)(undefined);


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
2 issues are solved :

1. When logging out from Microsoft account, provider.endSessionEndpoint is used. However that property does not exist for provider Microsoft. This result in an invalid url :
`https://login.microsoftonline.com/commonundefined?id_token_hint...`

2. When logging out from Google and/or Microsoft account the check at line 95 in `tns-oauth-login-sub-controller.ts` :
`url === this.client.provider.options.redirectUri` fails as the incoming url contains more than just the redirectUri. Because of that the wrong codeblock is executed and the console log shows an error `ERROR  400 ERROR Occurred`. This is not correct.

## What is the new behavior?
<!-- Describe the changes. -->
1. provider.endSession Endpoint now contains a value for Microsoft.
2. instead of checking for equality now check if url startsWith redirectUri

Fixes/Implements/Closes #[Issue Number]. #143