### PR TITLE
fix tsconfig.json in angular demo

### DIFF
--- a/demo-angular/tsconfig.json
+++ b/demo-angular/tsconfig.json
@@ -14,7 +14,13 @@
       "~/*": ["app/*"]
     }
   },
-  "include": ["src/tests/**/*.ts", "src/**/*.ios.ts", "src/**/*.android.ts"],
-  "files": ["./references.d.ts", "./src/main.ts", "../src/oauth.ts"],
-  "exclude": ["node_modules", "platforms", "e2e"]
+  "include": ["./src/**/*.ts", "../src/**/*.ts"],
+  "exclude": ["node_modules", "platforms", "e2e",
+         "../src/pkce-util.android.ts",
+         "../src/pkce-util.ios.ts",
+         "../src/tns-oauth-native-view-controller.android.ts",
+         "../src/tns-oauth-native-view-controller.ios.ts",
+         "../src/delegate/index.android.ts",
+         "../src/delegate/index.ios.ts"
+  ]
 }


### PR DESCRIPTION
## What is the current behavior?

When running `tns build android`, there is an error:
```
ERROR in ../src/tns-oauth-native-view-controller.ts:21:14 - error TS2339: Property 'browser' does not exist on type 'typeof androidx'.

21   ? androidx.browser?.customtabs
```
I think the error comes from the fact that the typescript file is not compiled into javascript because it is not included in tsconfig.json.

## What is the new behavior?

No error.

## How to reproduce?

`ns --version`: 7.0.11
`node --version`: v12.21.0

``` bash
git clone https://github.com/BBazard/nativescript-oauth2 --branch fix-angular-demo-android fix
cd fix/demo-angular
tns build android # important
tns debug android
```

## More info

- Tested on android device.
- The `tns build android` before the `tns debug android` is important to avoid the problem mentioned by https://github.com/alexziskind1/nativescript-oauth2/issues/141#issuecomment-738086773 aka "Application entry point file not found.".

Fixes #134 #141