### PR TITLE
#168 add client_id and token_type_hint

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-oauth2",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "OAuth 2 generic authorization plugin for NativeScript that doesn't install third party native libraries",
   "main": "oauth",
   "typings": "index.d.ts",

--- a/src/tns-oauth-client-connection.ts
+++ b/src/tns-oauth-client-connection.ts
@@ -90,8 +90,11 @@ export class TnsOAuthClientConnection {
     const headers = {
       "Content-Type": "application/x-www-form-urlencoded",
     };
+    const options = <TnsOaOpenIdProviderOptions>this.client.provider.options;
     const body = querystring.stringify({
+      client_id: options.clientId,
       token: this.client.tokenResult.refreshToken,
+      token_type_hint: "refresh_token"
     });
 
     Http.request({


### PR DESCRIPTION
## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
https://github.com/alexziskind1/nativescript-oauth2/issues/168

## What is the new behavior?
Exactly the same. it just supports more providers that need client_id as authentication on the token revoke request.

Fixes/Closes #168 .

