### PR TITLE
fix(ios): This changes the delegate to use @NativeClass.

### DIFF
--- a/src/delegate/index.ios.ts
+++ b/src/delegate/index.ios.ts
@@ -14,14 +14,16 @@ function setup() {
     private static getAppDelegate() {
       // Play nice with other plugins by not completely ignoring anything already added to the appdelegate
       if (applicationModule.ios.delegate === undefined) {
-        @ObjCClass(UIApplicationDelegate)
-        class UIApplicationDelegateImpl extends UIResponder implements UIApplicationDelegate { }
-  
+        @NativeClass
+        class UIApplicationDelegateImpl extends UIResponder implements UIApplicationDelegate {
+          public static ObjCProtocols = [UIApplicationDelegate];
+        }
+
         applicationModule.ios.delegate = UIApplicationDelegateImpl;
       }
       return applicationModule.ios.delegate;
     }
-  
+
     private static addAppDelegateMethods = appDelegate => {
       // iOS >= 10
       appDelegate.prototype.applicationOpenURLOptions = (
@@ -39,7 +41,7 @@ function setup() {
         TnsOAuthClientAppDelegate.handleIncomingUrl(url);
       };
     }
-  
+
     public static doRegisterDelegates() {
       this.addAppDelegateMethods(this.getAppDelegate());
     }


### PR DESCRIPTION
I followed the example set out by the core NativeScript tests [here](https://github.com/NativeScript/NativeScript/blob/17c85107ba84953630b0471c1f6f3d68f6d59f76/apps/automated/src/application/application-tests.ios.ts#L24) and changed to use `@NativeClass`.

I have only tested this compatibility with {N} 8.1.