### PR TITLE
(fix) refreshTokenWithCompletion does not complete if the variables this.provider.tokenEndpoint or this.tokenResult do not exist

### DIFF
--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -195,10 +195,10 @@ export class TnsOAuthClient {
     completion?: TnsOAuthClientLoginBlock
   ) {
     if (!this.provider.tokenEndpoint) {
-      return;
+      return completion(null, 'Provider End-point token is missing');
     }
     if (!this.tokenResult) {
-      return;
+      return completion(null, 'Token Result is missing');
     }
 
     const connection: TnsOAuthClientConnection = TnsOAuthClientConnection.initWithRequestClientCompletion(


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?

The Promise returned by the function `refreshTokenWithCompletion` does not complete if the variables `this.provider.tokenEndpoint` or `this.tokenResult` do not exist.

More details in the issue #191 

## What is the new behavior?

The Promise returned by the function `refreshTokenWithCompletion` will complete with an error if the variables `this.provider.tokenEndpoint` or `this.tokenResult` do not exist.

Fixes/Closes #191 

